### PR TITLE
Add clang's thread-sanitizer and address-sanitizer to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.a
+*.o
+*.so
+gmon.out
+mpsc_test

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
 # 2015 Daniel Bittman <danielbittman1@gmail.com>: http://dbittman.github.io/
 
-CFLAGS=-Wall -Wextra -Werror -std=gnu11 -O2 -pg
+CFLAGS=-Wall -Wextra -Werror -std=gnu11 -O3 -pg
 LDFLAGS=-lpthread -pg
 CC=gcc
+
+ifeq ($(strip $(DEBUG)),tsan)
+	CC=clang
+	CFLAGS+=-fsanitize=thread
+	LDFLAGS+=-fsanitize=thread
+else ifeq ($(strip $(DEBUG)),asan)
+	CC=clang
+	CFLAGS+=-fsanitize=address
+	LDFLAGS+=-fsanitize=address
+endif
+
 all: libmpscq.so libmpscq.a mpsc_test
 
-mpsc_test: mpscq.h mpsc.o mpsc_test.o
+mpsc_test: mpsc.o mpsc_test.o
 
 mpsc_test.o: mpsc_test.c
 

--- a/mpsc.c
+++ b/mpsc.c
@@ -7,10 +7,6 @@
 
 #include "mpscq.h"
 
-#define memory_order_release memory_order_seq_cst
-#define memory_order_acquire memory_order_seq_cst
-#define memory_order_relaxed memory_order_seq_cst
-
 /* multi-producer, single consumer queue *
  * Requirements: max must be >= 2 */
 struct mpscq *mpscq_create(struct mpscq *n, size_t capacity)

--- a/mpsc_test.c
+++ b/mpsc_test.c
@@ -13,14 +13,14 @@ _Atomic int amount_consumed = ATOMIC_VAR_INIT(0);
 _Atomic bool done = ATOMIC_VAR_INIT(false);
 _Atomic int retries = ATOMIC_VAR_INIT(0);
 _Atomic long long total = ATOMIC_VAR_INIT(0);
-#define NUM_ITEMS 100
-#define NUM_THREADS 128
+#define NUM_ITEMS 10000
+#define NUM_THREADS 32
 
 struct item {
 	_Atomic int sent, recv;
 };
 
-_Atomic struct item items[NUM_THREADS][NUM_ITEMS];
+struct item items[NUM_THREADS][NUM_ITEMS];
 
 void *producer_main(void *x)
 {


### PR DESCRIPTION
I see some concerns were raised in #2, so I added a little tooling for clang's thread-sanitizer and removed the strong memory guarantees for the heck of it and everything still seems cool. :+1:

example:
`DEBUG=tsan make && ./mpsc_test 32`